### PR TITLE
Features/new project in group

### DIFF
--- a/src/controllers/group_controller.js
+++ b/src/controllers/group_controller.js
@@ -250,7 +250,7 @@ exports.listGroupByProject = async (req, res) => {
     }
 };
 
-exports.insertProject = (req, res) => {
+exports.insertProject = async (req, res) => {
     try {
         const projectId = req.params.projectId;
         const groupId = req.params.groupId;

--- a/src/controllers/group_controller.js
+++ b/src/controllers/group_controller.js
@@ -22,19 +22,19 @@ exports.getAllGroups = async (req, res) => {
 
     try {
         const list = await Group.find({
-            "$or": [{
-                    "members": decoded.user.id
-                },
-                {
-                    "admin": decoded.user.id
-                }
-            ]
-        }, null, {
-            skip: firstIndex,
-            limit: perPage
-        })
-        .populate("admin", ['email', 'firstname', 'lastname', 'groups', 'avatar'])
-        .populate("members", ['email', 'firstname', 'lastname', 'groups', 'avatar']);
+                "$or": [{
+                        "members": decoded.user.id
+                    },
+                    {
+                        "admin": decoded.user.id
+                    }
+                ]
+            }, null, {
+                skip: firstIndex,
+                limit: perPage
+            })
+            .populate("admin", ['email', 'firstname', 'lastname', 'groups', 'avatar'])
+            .populate("members", ['email', 'firstname', 'lastname', 'groups', 'avatar']);
 
         res.json(list);
     } catch (e) {
@@ -245,6 +245,44 @@ exports.listGroupByProject = async (req, res) => {
             message: "list groups",
             data: groups
         });
+    } catch (err) {
+        errorHandler(err, res);
+    }
+};
+
+exports.insertProject = (req, res) => {
+    try {
+        const projectId = req.params.projectId;
+        const groupId = req.params.groupId;
+        await projectServices.checkValidProjectId(projectId);
+        await groupServices.checkValidGroupId(groupId);
+        const group = await Group.findById(groupId);
+        const project = await Project.findById(projectId);
+
+        if (!group) {
+            throw new AppError(translator.translate("GROUP_NOT_FOUND"), 404);
+        }
+        if (!project) {
+            throw new AppError(translator.translate("PROJECT_NOT_FOUND"), 404);
+        }
+        if (project.groups.indexOf(groupId) === -1) {
+            project.groups.push(groupId);
+        }
+        const updated = await Project
+            .findById(projectId)
+            .populate({
+                path: "groups",
+                populate: {
+                    path: "admin"
+                }
+            }).populate({
+                path: "groups",
+                populate: {
+                    path: "members"
+                }
+            });
+
+        res.json(updated)
     } catch (err) {
         errorHandler(err, res);
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,5 +45,6 @@
     "GROUP_NAME_TOO_LONG": "Group name too long !",
     "MEMBER_REQUIRED": "Members is required",
     "PROJECT_CLOSED": "The project is closed",
-    "GROUP_LIST": "Groups list"
+    "GROUP_LIST": "Groups list",
+    "PROJECT_NOT_FOUND": "The project is not found"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -45,5 +45,6 @@
     "GROUP_NAME_TOO_LONG": "Le nom du groupe est trop long !",
     "MEMBER_REQUIRED": "Des membres sont requis",
     "PROJECT_CLOSED": "Le projet est clos",
-    "GROUP_LIST": "Liste de groupes"
+    "GROUP_LIST": "Liste de groupes",
+    "PROJECT_NOT_FOUND": "Le projet n'est pas trouvé"
 }

--- a/src/routes/group/group_route.js
+++ b/src/routes/group/group_route.js
@@ -13,6 +13,9 @@ router.get("/groups/:groupId", jwtMiddleware.verify_token, groupController.getGr
 // List group by project
 router.get("/groups/project/:projectId", jwtMiddleware.verify_token, groupController.listGroupByProject);
 
+// Insert project in group
+router.put("/groups/:groupId/project/:projectId", [jwtMiddleware.verify_token, isAdminOf("GROUP")], groupController.insertProject);
+
 // Create Group
 router.post("/groups", jwtMiddleware.verify_token, groupController.createGroup);
 

--- a/src/routes/group/group_route.js
+++ b/src/routes/group/group_route.js
@@ -13,11 +13,11 @@ router.get("/groups/:groupId", jwtMiddleware.verify_token, groupController.getGr
 // List group by project
 router.get("/groups/project/:projectId", jwtMiddleware.verify_token, groupController.listGroupByProject);
 
-// Insert project in group
-router.put("/groups/:groupId/project/:projectId", [jwtMiddleware.verify_token, isAdminOf("GROUP")], groupController.insertProject);
-
 // Create Group
 router.post("/groups", jwtMiddleware.verify_token, groupController.createGroup);
+
+// Insert project in group
+router.put("/groups/:groupId/project/:projectId", [jwtMiddleware.verify_token, isAdminOf("GROUP")], groupController.insertProject);
 
 // Delete Group By Id
 router.delete("/groups/:groupId", [jwtMiddleware.verify_token, isAdminOf("GROUP")], groupController.deleteGroupById);


### PR DESCRIPTION
## Description

Project Timers allow us to log our task, and verify the time past on a project. The groups allow to log in the project are defined in the project interface. But, here we propose to see all projects linked to a group, and add project in this group view.

Changed proposed in this pull request:
- A new route that add groups in a project in the back-end side.
